### PR TITLE
fix: switch build backend to uv_build to correct package layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,14 @@ Repository = "https://github.com/mil-ad/kitcat.git"
 Issues = "https://github.com/mil-ad/kitcat/issues"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.11.13,<0.12.0"]
+build-backend = "uv_build"
 
-[tool.hatch.build]
-include = [
-    "src/kitcat",
+[dependency-groups]
+dev = [
+    "pre-commit>=4.0.1",
+    "ruff>=0.8.4",
 ]
 
 [project.entry-points."matplotlib.backend"]
-kitcat = "src.kitcat.backend"
+kitcat = "kitcat.backend"


### PR DESCRIPTION
The hatchling config (`[tool.hatch.build] include = ["src/kitcat"]`) shipped wheels with files at `src/kitcat/...` instead of `kitcat/...`, so installs landed in `site-packages/src/kitcat/` and polluted site-packages with a top-level `src/` directory. The matplotlib entry point `src.kitcat.backend` only resolved because it matched that broken layout.

Switch to the uv_build backend (matching `uv init --lib`), which auto-detects the src layout, and fix the entry point to `kitcat.backend`.


Fixes #10.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
